### PR TITLE
Fix invalid language code fallback

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -294,7 +294,10 @@ class TranslatorPage(QWidget):
             QMessageBox.warning(self, "Warning", "Please enter text to translate")
             return
         target_lang_name = self.lang_select.currentText()
-        target_lang_code = next((code for name, code in LANGUAGES if name == target_lang_name), target_lang_name)
+        target_lang_code = next(
+            (code for name, code in LANGUAGES if name == target_lang_name),
+            None,
+        )
         self.translate_button.setEnabled(False)
         self.translate_button.setText("Translating...")
         self.loading_spinner.start()


### PR DESCRIPTION
## Summary
- ensure `target_lang_code` defaults to `None`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc6e5670c832abd35a7fea0f885cc